### PR TITLE
Switch to MathJax

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,19 @@ We use [Material for MkDocs](https://github.com/squidfunk/mkdocs-material)
 1. Preview the site with `mkdocs serve`
 1. Make a Pull Request
 
+## Maths
+
+You can add maths via MathJax, both using inline syntax `$\sin(x)$`, which yields $\sin(x)$, and block syntax 
+```
+$$
+e = \sum \limits_{n=0}^{\infty}{\frac{1}{n!}}
+$$
+```
+which yields
+$$
+e = \sum \limits_{n=0}^{\infty}{\frac{1}{n!}}.
+$$
+
 ## Authors
 
 - Author 1 - <email@example.com>

--- a/README.md
+++ b/README.md
@@ -22,16 +22,8 @@ We use [Material for MkDocs](https://github.com/squidfunk/mkdocs-material)
 
 ## Maths
 
-You can add maths via MathJax, both using inline syntax `$\sin(x)$`, which yields $\sin(x)$, and block syntax 
-```
-$$
-e = \sum \limits_{n=0}^{\infty}{\frac{1}{n!}}
-$$
-```
-which yields
-$$
-e = \sum \limits_{n=0}^{\infty}{\frac{1}{n!}}.
-$$
+This template is already [configured](https://squidfunk.github.io/mkdocs-material/reference/math/#mathjax-mkdocsyml) for MathJax to work, both [using](https://squidfunk.github.io/mkdocs-material/reference/math/?h=math#usage) inline and block syntax.
+
 
 ## Authors
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -70,11 +70,10 @@ markdown_extensions:
   - pymdownx.superfences
   - def_list
 extra_javascript:
-  - javascripts/katex.js 
-  - https://cdnjs.cloudflare.com/ajax/libs/KaTeX/0.16.7/katex.min.js  
-  - https://cdnjs.cloudflare.com/ajax/libs/KaTeX/0.16.7/contrib/auto-render.min.js
-extra_css:
-  - https://cdnjs.cloudflare.com/ajax/libs/KaTeX/0.16.7/katex.min.css
+  - javascripts/mathjax.js
+  - https://polyfill.io/v3/polyfill.min.js?features=es6
+  - https://cdn.jsdelivr.net/npm/mathjax@3/es5/tex-mml-chtml.js
+
 nav:
   - Home: index.md
   - Reference Sheet: reference.md


### PR DESCRIPTION
Switch to MathJax [configuration](https://squidfunk.github.io/mkdocs-material/reference/math/#mathjax-mkdocsyml) instead of KaTeX. Resolves #10 .